### PR TITLE
docs: add document bot privacy compliance

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,20 @@
+# ClashKing Bot Privacy
+
+ClashKing Bot can connect Discord users, Discord servers, and Clash of Clans player tags. These links are personal data when they identify a person or a server member.
+
+## What the bot may process
+
+- Discord user IDs, usernames, display names, avatars, guild IDs, channel IDs, role IDs, and permission context.
+- Clash of Clans player tags, clan tags, account links, rosters, reminders, tickets, strikes, and role configuration.
+- Attachments or transcripts created through ticketing and support workflows.
+- Command usage and operational logs needed to keep the bot reliable and secure.
+
+## Your choices
+
+- Server administrators can remove server configuration, rosters, reminders, tickets, and role automation through bot/dashboard controls.
+- Users can request export, unlinking, correction, or deletion of Discord-linked records by contacting ClashKing support with enough information to verify the Discord account and affected server.
+- ClashKing does not sell bot data or share it for behavioral advertising.
+
+## Retention
+
+ClashKing keeps bot records only while needed for the configured feature, security, moderation, audit, or legal obligations. Account links, reminders, and tickets should be removed or anonymized when a verified deletion request is completed unless the record must be retained for moderation or legal reasons.

--- a/docs/privacy_compliance.md
+++ b/docs/privacy_compliance.md
@@ -1,0 +1,33 @@
+# Privacy Compliance Notes
+
+ClashKing Bot operates inside Discord servers and can connect Discord identities to Clash of Clans player tags, rosters, reminders, tickets, strikes, roles, and server configuration. Those links are personal data for global privacy regimes.
+
+## Data handled here
+
+- Discord user IDs, usernames/display names, avatars, guild IDs, channel IDs, role IDs, and server configuration.
+- Clash of Clans player tags, clan tags, API-token verification results, account links, rosters, reminders, tickets, strikes, and application records.
+- Uploaded attachments/transcripts stored through the configured CDN for ticketing and support workflows.
+- Command usage and operational statistics.
+
+## User rights process
+
+For verified requests, operators must be able to:
+
+- Export Discord-linked records, including linked player tags, reminders, roster entries, tickets owned by the user, strike records, profile/settings entries, and command/account-link metadata.
+- Delete or anonymize Discord-linked records where there is no overriding security, audit, or legal reason to retain them.
+- Unlink Clash of Clans player tags from the requesting Discord user through the link client and local collections.
+- Remove CDN ticket transcripts or attachments owned by the requester when they are no longer required for moderation or legal obligations.
+
+## Collection limits
+
+- Do not store Clash of Clans API tokens after verification.
+- Do not expose Discord OAuth/client secrets, bot tokens, CDN keys, or database credentials in logs or command output.
+- Keep moderation/audit records access-restricted to server operators with a valid need.
+- Avoid sending personal data in public channels; use ephemeral responses or direct messages for account-link and privacy workflows where possible.
+
+## Global deployment checklist
+
+- GDPR/UK GDPR/LGPD/PIPEDA/APPI/PIPL/PDPA: access, deletion, correction, portability, minimization, retention, and security.
+- CCPA/CPRA: disclosure, deletion/correction, and no sale/share for behavioral advertising.
+- COPPA/children rules: do not knowingly collect children-specific data; rely on Discord/App Store/Google Play age gates and remove data if a child-data request is verified.
+- ePrivacy and push messaging: only send notification/reminder messages that users or server administrators configured, and honor opt-outs promptly.


### PR DESCRIPTION
## Summary
- add a public bot privacy notice covering Discord IDs, player links, rosters, reminders, tickets, strikes, and CDN transcripts
- document operator runbooks for export, unlinking, correction, and deletion requests
- define global compliance expectations for GDPR-style rights, CCPA/CPRA, COPPA, and push/reminder messaging

## Validation
- Documentation-only change; no runtime tests run