### PR TITLE
chore(l10n): configure Crowdin

### DIFF
--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,6 +1,10 @@
+preserve_hierarchy: true
+
 files:
-  - source: locales/en-US/*.ftl
+  - source: /locales/en-US/*.ftl
+    dest: /bot/%file_name%.ftl
     translation: /locales/%locale%/%file_name%.ftl
+    update_option: update_as_unapproved
 
     languages_mapping:
       locale:
@@ -35,3 +39,5 @@ files:
         ro: ro
         fi: fi
         sv-SE: sv-SE
+
+commit_message: "chore(l10n): new Crowdin translations"


### PR DESCRIPTION
## What changed

- Normalized the existing Fluent catalog mapping for Crowdin.
- Preserved locale hierarchy and added a dedicated `/bot/` destination.
- Marked source updates as unapproved and added the Conventional Commit message for Crowdin translation commits.

## Why

The existing `.ftl` catalogs are runtime-neutral and can be retained during the planned Python-to-Go rewrite, avoiding a translation reset or a second catalog format.

## Validation

- Parsed `crowdin.yml` and asserted its source, destination, translation, update, hierarchy, and commit-message mappings.
- Ran `git diff --check`.
